### PR TITLE
Add file to build and install with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+project(GPC LANGUAGES C)
+add_library(GPC gpc.c gpc.h)
+
+# Installation:
+install(TARGETS GPC EXPORT ${PROJECT_NAME}Targets INCLUDES DESTINATION include)
+install(FILES gpc.h TYPE INCLUDE)
+install(EXPORT ${PROJECT_NAME}Targets DESTINATION
+  lib/cmake/${PROJECT_NAME} NAMESPACE ${PROJECT_NAME}:: FILE
+  ${PROJECT_NAME}Config.cmake)
+
+export(EXPORT ${PROJECT_NAME}Targets NAMESPACE ${PROJECT_NAME}:: FILE
+  ${PROJECT_NAME}Config.cmake)


### PR DESCRIPTION
Building GPC with CMake is especially useful to refer to GPC in a consumer project which is built with CMake.